### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ knight
 
 One HTTP web server with reloader for Go, knight detects file changes and restart the server automatically.
 
-##install
+## install
     
     $ go get github.com/fengsp/knight
 
-##usage
+## usage
 Basically you just need to set one watching path.
 
 ```Go


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
